### PR TITLE
Update toolchain

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,4 +16,4 @@
 ## Infrastructure
 
 - [x] Add GitHub Actions for build, unit tests, and crate publishing
-- [ ] Remove `nightly` dependency in `cortex-m` crate: Using `naked_functions` feature for context switching
+- [x] Remove `nightly` dependency in `cortex-m` crate: Using `naked_functions` feature for context switching

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["rtos", "arm", "cortex-m"]
 
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
+naked-function = "0.1.5"
 rucos = { version = "0.1.1", path = "../kernel" }
 
 [dev-dependencies]

--- a/cortex-m/rust-toolchain.toml
+++ b/cortex-m/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = [ "rustfmt" ]
 targets = [ "thumbv7em-none-eabihf" ]


### PR DESCRIPTION
The `rucos-cortex-m` crate can now be compiled on `stable` since naked functions are supported via the `naked_functions` crate.

By default the Rust compiler now generates more warnings when using a `static mut`. The `KERNEL` singleton is refactored to use `Mutex` and `RefCell` and a `with_kernel` helper function is added to reduce boilerplate.

- [ ] No regressions with `cargo run --example task_basic`
- [ ] No regressions with `cargo run --example task_advanced`