### PR TITLE
Update toolchain (redux)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,4 +16,4 @@
 ## Infrastructure
 
 - [x] Add GitHub Actions for build, unit tests, and crate publishing
-- [ ] Remove `nightly` dependency in `cortex-m` crate: Using `naked_functions` feature for context switching
+- [x] Remove `nightly` dependency in `cortex-m` crate: Using `naked_functions` feature for context switching

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["rtos", "arm", "cortex-m"]
 
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
+naked-function = "0.1.5"
 rucos = { version = "0.1.1", path = "../kernel" }
 
 [dev-dependencies]

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rucos-cortex-m"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Ben Brown <ben@beninter.net>"]
 edition = "2021"
 description = "A port of the RuCOS kernel to ARM Cortex-M"
@@ -16,11 +16,11 @@ rucos = { version = "0.1.1", path = "../kernel" }
 
 [dev-dependencies]
 cortex-m-rt = "0.7.3"
-defmt = "0.3"
-defmt-rtt = "0.4"
-defmt-test = "0.3"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
-stm32f7xx-hal = { version = "0.7.0", features = ["rt", "stm32f767"] }
+defmt = "1.0.1"
+defmt-rtt = "1.0"
+defmt-test = "0.4"
+panic-probe = { version = "1.0", features = ["print-defmt"] }
+stm32f7xx-hal = { version = "0.8.0", features = ["rt", "stm32f767"] }
 
 [[test]]
 name = "template"

--- a/cortex-m/rust-toolchain.toml
+++ b/cortex-m/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = [ "rustfmt" ]
 targets = [ "thumbv7em-none-eabihf" ]

--- a/cortex-m/src/lib.rs
+++ b/cortex-m/src/lib.rs
@@ -1,7 +1,6 @@
 //! A port of the RuCOS kernel to ARM Cortex-M
 
 #![no_std]
-#![feature(naked_functions)]
 
 use core::arch::asm;
 use core::mem::MaybeUninit;
@@ -259,32 +258,29 @@ pub extern "C" fn SysTick() {
 /// PendSV interrupt handler
 ///
 /// Context switch implementation
-#[naked]
 #[no_mangle]
-pub extern "C" fn PendSV() {
-    unsafe {
-        // TODO: Replace disabling interrupts with BASEPRI adjustment
-        asm!(
-            "cpsid     i",                    // Disable interrupts
-            "mrs       r0, psp",              // Read PSP
-            "mov       r1, lr",               // Save LR
-            "tst       r14, #0x10",           // Check if FPU is being used
-            "it        eq",                   // ...
-            "vstmdbeq  r0!, {{s16-s31}}",     // Push the FPU registers
-            "stmdb     r0!, {{r4-r11, r14}}", // Push the CPU registers
-            "push      {{r1}}",               // Push LR
-            "bl        context_switch",       // context_switch(R0) -> R0
-            "pop       {{r1}}",               // Pop LR
-            "ldmia     r0!, {{r4-r11, r14}}", // Pop the CPU registers
-            "tst       r14, #0x10",           // Check if FPU is being used
-            "it        eq",                   // ...
-            "vldmiaeq  r0!, {{s16-s31}}",     // Pop the FPU registers
-            "msr       psp, r0",              // Write PSP
-            "cpsie     i",                    // Enable interrupts
-            "bx        r1",                   // Branch to next task
-            options(noreturn),
-        );
-    }
+#[naked_function::naked]
+pub unsafe extern "C" fn PendSV() {
+    // TODO: Replace disabling interrupts with BASEPRI adjustment
+    asm!(
+        "cpsid     i",                    // Disable interrupts
+        "mrs       r0, psp",              // Read PSP
+        "mov       r1, lr",               // Save LR
+        "tst       r14, #0x10",           // Check if FPU is being used
+        "it        eq",                   // ...
+        "vstmdbeq  r0!, {{s16-s31}}",     // Push the FPU registers
+        "stmdb     r0!, {{r4-r11, r14}}", // Push the CPU registers
+        "push      {{r1}}",               // Push LR
+        "bl        context_switch",       // context_switch(R0) -> R0
+        "pop       {{r1}}",               // Pop LR
+        "ldmia     r0!, {{r4-r11, r14}}", // Pop the CPU registers
+        "tst       r14, #0x10",           // Check if FPU is being used
+        "it        eq",                   // ...
+        "vldmiaeq  r0!, {{s16-s31}}",     // Pop the FPU registers
+        "msr       psp, r0",              // Write PSP
+        "cpsie     i",                    // Enable interrupts
+        "bx        r1",                   // Branch to next task
+    );
 }
 
 /// Perform a context switch


### PR DESCRIPTION
`rucos-cortex-m` crate can now be compiled on `stable` since naked functions are supported via the `naked-functions` crate.

- [x] No regressions with `cargo run --example task_basic`
- [x] No regressions with `cargo run --example task_advanced`