### PR TITLE
Bump kernel version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Build & Test
 
 on:
   push:
+    branches:
+      master
   pull_request:
 
 env:

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["rtos", "arm", "cortex-m"]
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 naked-function = "0.1.5"
-rucos = { version = "0.1.1", path = "../kernel" }
+rucos = { version = "0.2.0", path = "../kernel" }
 
 [dev-dependencies]
 cortex-m-rt = "0.7.3"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rucos"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Ben Brown <ben@beninter.net>"]
 edition = "2021"
 description = "Rust Microcontroller Operating System (RuCOS) Kernel"


### PR DESCRIPTION
Crates should stay in lock-step. Did not bump `rucos` crate in #4.