### PR TITLE
Rewrite without singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,20 @@ real-time kernel for embedded Rust applications (`no_std`).
 - Do not use the `async`/`await` pattern
 - Do not require memory management or protection hardware
 - Do not use experimental language features: Compile on `stable`
-- Portable: Clearly separate platform specific code from the kernel
+- Portable: Clearly separate platform specific and generic code
 - Tested: Thanks to portability, we can unit test the kernel on the host
-- Use Rust language features to ensure memory and thread safety at compile time
 
 ## User Guide
 
 ### Architecture
 
-The [`rucos`](kernel) crate is a collection of `no_std` data structures. It has
-no platform specific or `unsafe` code. The `Kernel` struct is designed to be
-used as a singleton in an embedded application.
-
-The `rucos` crate would be difficult to use alone, as the embedded application
-needs a mutable reference to the `Kernel` singleton in every task. This is
-where the "port specific" crate comes in (e.g. [`rucos-cortex-m`](cortex-m)).
-The port specific crate creates wrappers around the `Kernel` APIs, dealing with
-platform specific details (e.g. stack initialization) and handling the `Kernel`
-singleton in a safe way (e.g. disabling interrupts).
+The [`rucos`](kernel) crate is a collection of `no_std` data structures and
+a very simple scheduler. It has no platform specific code or and almost no
+`unsafe` code. Aside to the `Task` data strcuture, the `rucos` crate is not
+designed to be directly used by end users. Instead, a "port specific" crate,
+like [`rucos-cortex-m`](cortex-m) should be used. The port specific crate
+handles architecture details like stack initialization and context switching,
+and ensures scheduling is done in a safely (e.g. disabling interrupts).
 
 ### Getting Started
 
@@ -37,18 +33,21 @@ calling a few APIs.
 ```rust
 use rucos_cortex_m as rucos;
 
+// ID = 6, Priority = 0 (highest priority)
+static MY_TASK: rucos::Task = rucos::Task::new(6, 0);
+
 let my_task = |_: u32| -> ! {
     loop {
         info!("Hello from Task {}", rucos::get_current_task());
-        rucos::sleep(rucos::TICK_RATE_HZ);
+        rucos::sleep(TICK_RATE_HZ);
     }
 };
 
-let mut idle_stack: [u8; IDLE_STACK_SIZE] = [0; IDLE_STACK_SIZE];
-let mut my_task_stack: [u8; TASK_STACK_SIZE] = [0; TASK_STACK_SIZE];
+let idle_stack: [u8; IDLE_STACK_SIZE] = [0; IDLE_STACK_SIZE];
+let my_task_stack: [u8; TASK_STACK_SIZE] = [0; TASK_STACK_SIZE];
 
-rucos::init(&mut idle_stack, None);
-rucos::create(0, 10, &mut my_task_stack, my_task, None);
+rucos::init(&idle_stack, None);
+rucos::create(&MY_TASK, &my_task_stack, my_task, None);
 rucos::start(...);
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,15 +3,14 @@
 ## Features
 
 - [x] Implement multi-tasking
+- [ ] Implement inter-task communication
 - [ ] Implement synchronization primitives
-- [ ] Implement static memory pools with `Drop` trait
-- [ ] Implement inter-task communication with `Send` and `Sync` traits
-- [ ] Support time slicing if tasks with the same priority are ready
+- [ ] Implement time slicing for tasks with the same priority
 
 ## Ports
 
-- [x] Create a `cortex-m` port
-- [ ] Create a `risc-v` port
+- [x] Create `cortex-m` port
+- [ ] Create `risc-v` port
 
 ## Infrastructure
 

--- a/cortex-m/Cargo.toml
+++ b/cortex-m/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rucos-cortex-m"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ben Brown <ben@beninter.net>"]
 edition = "2021"
 description = "A port of the RuCOS kernel to ARM Cortex-M"
@@ -12,7 +12,7 @@ keywords = ["rtos", "arm", "cortex-m"]
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 naked-function = "0.1.5"
-rucos = { version = "0.2.0", path = "../kernel" }
+rucos = { version = "0.3.0", path = "../kernel" }
 
 [dev-dependencies]
 cortex-m-rt = "0.7.3"

--- a/cortex-m/README.md
+++ b/cortex-m/README.md
@@ -152,20 +152,6 @@ has two issues with respect to the current design of `rucos-cortex-m`:
 
 #### Solution Ideas
 
-- Move `KERNEL` to the application
-    - Gives flexibility for memory placement
-    - `init()` and `start()` can be passed a mutable reference
-- Update kernel APIs to use `svc` instruction
-    - Acts as a function call into the kernel
-    - Does not require accessing the singleton
-- Make two versions of `create()`: Before and after kernel start
-    - Before kernel start: Pass in a mutable reference to kernel
-    - After kernel start: Using `svc` instruction, like other kernel APIs
-- Interrupts (SysTick, PendSV, SVCall):
-    - Likely need to bind pointer to `KERNEL` in `start()` for ISRs
-    - Initial implementation can disable interrupts (`Mutex<RefCell<T>>` pattern)
-    - Then need to think more about atomics and other primitives
-- Could `Kernel` struct be lighterweight?
-    - Each task could have a reference to it's own "TCB" (`Task` struct)
-    - Does a linked-list implementation avoid needing a `Vec`?
-    - Kernel could use `Atomic` data types for other state (`core::sync::atomic`)
+Refactor to avoid needing `KERNEL` singleton that needs to be mutated. Instead
+use `static` variables that are `Atomic` (`core::sync::atomic`). The PendSV ISR
+will continue to run with interrupts disabled to perform a context switch.

--- a/cortex-m/examples/common/mod.rs
+++ b/cortex-m/examples/common/mod.rs
@@ -5,11 +5,18 @@ use rucos_cortex_m as rucos;
 use stm32f7xx_hal::rcc::Clocks;
 use stm32f7xx_hal::{pac, prelude::*};
 
+pub const TICK_RATE_HZ: u32 = 1000;
+
 pub const IDLE_STACK_SIZE: usize = 256;
-pub const TASK_STACK_SIZE: usize = 2048;
+pub const TASK_STACK_SIZE: usize = 512;
+
+pub const TASK0_ID: usize = 0;
+pub const TASK1_ID: usize = 1;
+pub const TASK0_PRIO: u8 = 10;
+pub const TASK1_PRIO: u8 = 11;
 
 // NOTE: Kernel must be initialized before using defmt macros
-defmt::timestamp!("{=u64:us}", rucos::get_current_tick());
+defmt::timestamp!("{=u32:ms}", rucos::get_current_tick());
 
 pub struct KernelResources {
     pub scb: SCB,

--- a/cortex-m/examples/common/mod.rs
+++ b/cortex-m/examples/common/mod.rs
@@ -8,7 +8,7 @@ use stm32f7xx_hal::{pac, prelude::*};
 pub const TICK_RATE_HZ: u32 = 1000;
 
 pub const IDLE_STACK_SIZE: usize = 256;
-pub const TASK_STACK_SIZE: usize = 512;
+pub const TASK_STACK_SIZE: usize = 1024;
 
 pub const TASK0_ID: usize = 0;
 pub const TASK1_ID: usize = 1;

--- a/cortex-m/examples/task_advanced.rs
+++ b/cortex-m/examples/task_advanced.rs
@@ -12,16 +12,19 @@ mod common;
 use defmt::info;
 use rucos_cortex_m as rucos;
 
+static TASK0: rucos::Task = rucos::Task::new(common::TASK0_ID, common::TASK0_PRIO);
+static TASK1: rucos::Task = rucos::Task::new(common::TASK1_ID, common::TASK1_PRIO);
+
 fn task0(_: u32) -> ! {
     let mut counter = 0;
 
     loop {
         if counter == 5 {
             info!("Task 0 suspending itself");
-            rucos::suspend(None);
+            rucos::suspend(common::TASK0_ID);
         } else {
             info!("Hello from Task {}", rucos::get_current_task());
-            rucos::sleep(rucos::TICK_RATE_HZ);
+            rucos::sleep(common::TICK_RATE_HZ);
         }
 
         counter += 1;
@@ -35,17 +38,17 @@ fn task1(_: u32) -> ! {
         if counter == 10 {
             info!("Task 1 resuming Task 0");
             rucos::resume(0);
-            rucos::sleep(rucos::TICK_RATE_HZ);
+            rucos::sleep(common::TICK_RATE_HZ);
         } else if counter == 15 {
             info!("Task 1 deleting Task 0");
-            rucos::delete(Some(0));
-            rucos::sleep(rucos::TICK_RATE_HZ);
+            rucos::delete(common::TASK0_ID);
+            rucos::sleep(common::TICK_RATE_HZ);
         } else if counter == 20 {
             info!("Task 1 deleting itself");
-            rucos::delete(None);
+            rucos::delete(common::TASK1_ID);
         } else {
             info!("Hello from Task {}", rucos::get_current_task());
-            rucos::sleep(rucos::TICK_RATE_HZ);
+            rucos::sleep(common::TICK_RATE_HZ);
         }
 
         counter += 1;
@@ -56,21 +59,22 @@ fn task1(_: u32) -> ! {
 fn main() -> ! {
     let mut resources = common::setup();
 
-    let mut idle_stack: [u8; common::IDLE_STACK_SIZE] = [0; common::IDLE_STACK_SIZE];
-    rucos::init(&mut idle_stack, None);
+    let idle_stack: [u8; common::IDLE_STACK_SIZE] = [0; common::IDLE_STACK_SIZE];
+    rucos::init(&idle_stack, None);
 
     info!("Creating Task 0");
-    let mut task0_stack: [u8; common::TASK_STACK_SIZE] = [0; common::TASK_STACK_SIZE];
-    rucos::create(0, 0, &mut task0_stack, task0, None);
+    let task0_stack: [u8; common::TASK_STACK_SIZE] = [0; common::TASK_STACK_SIZE];
+    rucos::create(&TASK0, &task0_stack, task0, None);
 
     info!("Creating Task 1");
-    let mut task1_stack: [u8; common::TASK_STACK_SIZE] = [0; common::TASK_STACK_SIZE];
-    rucos::create(1, 1, &mut task1_stack, task1, None);
+    let task1_stack: [u8; common::TASK_STACK_SIZE] = [0; common::TASK_STACK_SIZE];
+    rucos::create(&TASK1, &task1_stack, task1, None);
 
     info!("Starting");
     rucos::start(
         &mut resources.scb,
         &mut resources.systick,
         resources.clocks.hclk().to_Hz(),
+        common::TICK_RATE_HZ,
     );
 }

--- a/cortex-m/examples/task_basic.rs
+++ b/cortex-m/examples/task_basic.rs
@@ -9,13 +9,13 @@ mod common;
 use defmt::info;
 use rucos_cortex_m as rucos;
 
-fn task_template(arg: u32) -> ! {
-    let delay: u64 = arg as u64;
-    assert!(delay > 0);
+static TASK0: rucos::Task = rucos::Task::new(common::TASK0_ID, common::TASK0_PRIO);
+static TASK1: rucos::Task = rucos::Task::new(common::TASK1_ID, common::TASK1_PRIO);
 
+fn task_template(delay_sec: u32) -> ! {
     loop {
         info!("Hello from Task {}", rucos::get_current_task());
-        rucos::sleep(delay * rucos::TICK_RATE_HZ);
+        rucos::sleep(delay_sec * common::TICK_RATE_HZ);
     }
 }
 
@@ -23,21 +23,22 @@ fn task_template(arg: u32) -> ! {
 fn main() -> ! {
     let mut resources = common::setup();
 
-    let mut idle_stack: [u8; common::IDLE_STACK_SIZE] = [0; common::IDLE_STACK_SIZE];
-    rucos::init(&mut idle_stack, None);
+    let idle_stack: [u8; common::IDLE_STACK_SIZE] = [0; common::IDLE_STACK_SIZE];
+    rucos::init(&idle_stack, None);
 
     info!("Creating Task 0");
-    let mut task0_stack: [u8; common::TASK_STACK_SIZE] = [0; common::TASK_STACK_SIZE];
-    rucos::create(0, 0, &mut task0_stack, task_template, Some(2));
+    let task0_stack: [u8; common::TASK_STACK_SIZE] = [0; common::TASK_STACK_SIZE];
+    rucos::create(&TASK0, &task0_stack, task_template, Some(2));
 
     info!("Creating Task 1");
-    let mut task1_stack: [u8; common::TASK_STACK_SIZE] = [0; common::TASK_STACK_SIZE];
-    rucos::create(1, 1, &mut task1_stack, task_template, Some(1));
+    let task1_stack: [u8; common::TASK_STACK_SIZE] = [0; common::TASK_STACK_SIZE];
+    rucos::create(&TASK1, &task1_stack, task_template, Some(1));
 
     info!("Starting");
     rucos::start(
         &mut resources.scb,
         &mut resources.systick,
         resources.clocks.hclk().to_Hz(),
+        common::TICK_RATE_HZ,
     );
 }

--- a/cortex-m/src/lib.rs
+++ b/cortex-m/src/lib.rs
@@ -3,58 +3,16 @@
 #![no_std]
 
 use core::arch::asm;
-use core::cell::RefCell;
 use core::ptr::write_volatile;
-use cortex_m::interrupt::{free, CriticalSection, Mutex};
+use core::sync::atomic::Ordering;
 use cortex_m::peripheral::{scb, syst::SystClkSource, SCB, SYST};
-use rucos::Kernel;
+use rucos::kernel;
 
-/// Kernel tick rate in hertz
-pub const TICK_RATE_HZ: u64 = 1000;
+// Re-export to simplify things for the end user
+pub use rucos::task::Task;
 
-/// Maximum number of kernel tasks
-pub const MAX_NUM_TASKS: usize = 256;
-
-/// Helper for concrete types
-type KernelCM = Kernel<u32, u64, MAX_NUM_TASKS>;
-
-/// Kernel singleton
-static KERNEL: Mutex<RefCell<Option<KernelCM>>> = Mutex::new(RefCell::new(None));
-
-/// Helper for safely using the kernel
-///
-/// # Arguments
-///
-/// * `body`: Closure to run with the kernel
-///
-/// # Returns
-///
-/// Return value from `body`
-///
-/// # Panics
-///
-/// If called before the kernel is initialized
-fn with_kernel<R>(body: impl FnOnce(&mut KernelCM) -> R) -> R {
-    free(|cs| {
-        let mut binding = KERNEL.borrow(cs).borrow_mut();
-        let kernel = binding.as_mut().expect("Kernel not initialized");
-        body(kernel)
-    })
-}
-
-/// Helper for initializing a task stack
-///
-/// # Arguments
-///
-/// * `stack`: Task stack memory
-/// * `entry`: Task function
-/// * `arg`: An optional argument to pass to `entry`
-///
-/// # Returns
-///
-/// Task stack pointer
-fn init_task_stack(stack: &mut [u8], entry: fn(u32) -> !, arg: Option<u32>) -> u32 {
-    let mut stack_ptr = stack.as_mut_ptr() as u32 + stack.len() as u32;
+fn init_task_stack(stack: &[u8], entry: fn(u32) -> !, arg: Option<u32>) -> u32 {
+    let mut stack_ptr = stack.as_ptr() as u32 + stack.len() as u32;
     let arg = arg.unwrap_or(0);
 
     // Align the stack
@@ -98,19 +56,11 @@ fn init_task_stack(stack: &mut [u8], entry: fn(u32) -> !, arg: Option<u32>) -> u
 ///
 /// # Note
 ///
-/// The idle task is the lowest priority task and is always ready to run, it
-/// must not block or call any kernel APIs (e.g. `sleep`)
-pub fn init(idle_stack: &mut [u8], user_idle_task: Option<fn(u32) -> !>) {
-    let mut kernel = Kernel::new();
-
-    // Create the idle task
-    let stack_ptr = init_task_stack(idle_stack, user_idle_task.unwrap_or(idle_task), None);
-    kernel.create(usize::MAX, usize::MAX, stack_ptr);
-
-    // Bind the kernel singleton
-    free(|cs| {
-        *KERNEL.borrow(cs).borrow_mut() = Some(kernel);
-    });
+/// The idle task is the lowest priority task and is always ready to run, it must not block or call
+/// any kernel APIs (e.g. [`sleep`]).
+pub fn init(idle_stack: &[u8], user_idle_task: Option<fn(u32) -> !>) {
+    let idle_stack_ptr = init_task_stack(idle_stack, user_idle_task.unwrap_or(idle_task), None);
+    kernel::init(idle_stack_ptr);
 }
 
 /// Start the kernel
@@ -120,21 +70,23 @@ pub fn init(idle_stack: &mut [u8], user_idle_task: Option<fn(u32) -> !>) {
 /// * `scb`: System control block (from the `cortex-m` crate)
 /// * `systick`: System tick  (from the `cortex-m` crate)
 /// * `clock_freq_hz`: Core clock frequency in hertz
+/// * `tick_rate_hz`: System tick rate in hertz
 ///
 /// # Note
 ///
-/// Does not return: Program execution continues from tasks or interrupt
-/// handlers after calling this API
-pub fn start(scb: &mut SCB, systick: &mut SYST, clock_freq_hz: u32) -> ! {
-    let first_task_stack_ptr = with_kernel(|kernel| kernel.start());
+/// Does not return: Program execution continues from tasks or interrupt handlers after calling
+/// this API.
+pub fn start(scb: &mut SCB, systick: &mut SYST, clock_freq_hz: u32, tick_rate_hz: u32) -> ! {
+    let first_task = rucos::kernel::get_current_task().unwrap();
+    let first_task_stack_ptr = first_task.stack_ptr.load(Ordering::Relaxed);
 
-    systick.set_reload((clock_freq_hz / (TICK_RATE_HZ as u32)) - 1);
+    systick.set_reload((clock_freq_hz / tick_rate_hz) - 1);
     systick.clear_current();
     systick.set_clock_source(SystClkSource::Core);
     systick.enable_interrupt();
     systick.enable_counter();
 
-    // Safety: Should only be called from `main` to start multi-tasking
+    // Safety: Should only be called once from main() before multi-tasking starts
     unsafe {
         // Context switch should only happen once all interrupts have been serviced
         scb.set_priority(scb::SystemHandler::PendSV, 0xFF);
@@ -164,39 +116,28 @@ pub fn start(scb: &mut SCB, systick: &mut SYST, clock_freq_hz: u32) -> ! {
 ///
 /// # Arguments
 ///
-/// * `id`: Task ID
-/// * `priority`: Task priority, with a lower number meaning higher priority
+/// * `task`: Task control block
 /// * `stack`: Task stack memory
 /// * `entry`: Task function
 /// * `arg`: An optional argument to pass to `entry`
-///
-/// # Note
-///
-/// A context switch may occur after calling this API, if the kernel is running
-pub fn create(id: usize, priority: usize, stack: &mut [u8], entry: fn(u32) -> !, arg: Option<u32>) {
-    let stack_ptr = init_task_stack(stack, entry, arg);
-    with_kernel(|kernel| {
-        if kernel.create(id, priority, stack_ptr) {
-            SCB::set_pendsv();
-        }
-    });
+pub fn create(task: &'static Task, stack: &[u8], entry: fn(u32) -> !, arg: Option<u32>) {
+    let task_stack_ptr = init_task_stack(stack, entry, arg);
+    kernel::create(task, task_stack_ptr);
 }
 
 /// Delete a task
 ///
 /// # Arguments
 ///
-/// * `id`: Task to delete or `None` to delete the current task
+/// * `id`: Task to delete
 ///
 /// # Note
 ///
-/// A context switch may occur after calling this API
-pub fn delete(id: Option<usize>) {
-    with_kernel(|kernel| {
-        if kernel.delete(id) {
-            SCB::set_pendsv();
-        }
-    });
+/// A context switch may occur after calling this API.
+pub fn delete(id: usize) {
+    if kernel::delete(id) {
+        SCB::set_pendsv();
+    }
 }
 
 /// Get the ID of the current task
@@ -205,7 +146,7 @@ pub fn delete(id: Option<usize>) {
 ///
 /// ID of the current task
 pub fn get_current_task() -> usize {
-    with_kernel(|kernel| kernel.get_current_task())
+    kernel::get_current_task().unwrap().id
 }
 
 /// Get the current value of the kernel tick
@@ -216,9 +157,9 @@ pub fn get_current_task() -> usize {
 ///
 /// # Note
 ///
-/// Ticks correspond to system time based on `TICK_RATE_HZ`
-pub fn get_current_tick() -> u64 {
-    with_kernel(|kernel| kernel.get_current_tick())
+/// Ticks correspond to system time based on `tick_rate_hz` passed to [`start`].
+pub fn get_current_tick() -> u32 {
+    kernel::get_current_tick()
 }
 
 /// Sleep the current task
@@ -229,30 +170,26 @@ pub fn get_current_tick() -> u64 {
 ///
 /// # Note
 ///
-/// Ticks correspond to system time based on `TICK_RATE_HZ`
-pub fn sleep(delay: u64) {
-    with_kernel(|kernel| {
-        if kernel.sleep(delay) {
-            SCB::set_pendsv();
-        }
-    });
+/// Ticks correspond to system time based on `tick_rate_hz` passed to [`start`].
+pub fn sleep(delay: u32) {
+    if kernel::sleep(delay) {
+        SCB::set_pendsv();
+    }
 }
 
 /// Suspend a task
 ///
 /// # Arguments
 ///
-/// * `id`: Task to suspend or `None` to suspend the current task
+/// * `id`: Task to suspend
 ///
 /// # Note
 ///
-/// A context switch may occur after calling this API
-pub fn suspend(id: Option<usize>) {
-    with_kernel(|kernel| {
-        if kernel.suspend(id) {
-            SCB::set_pendsv();
-        }
-    });
+/// A context switch may occur after calling this API.
+pub fn suspend(id: usize) {
+    if kernel::suspend(id) {
+        SCB::set_pendsv();
+    }
 }
 
 /// Resume a task
@@ -260,36 +197,26 @@ pub fn suspend(id: Option<usize>) {
 /// # Arguments
 ///
 /// * `id`: Task to resume
-///
-/// # Note
-///
-/// A context switch may occur after calling this API
 pub fn resume(id: usize) {
-    with_kernel(|kernel| {
-        if kernel.resume(id) {
-            SCB::set_pendsv();
-        }
-    });
+    kernel::resume(id);
 }
 
 /// SysTick interrupt handler: System tick update
 #[no_mangle]
-pub extern "C" fn SysTick() {
-    with_kernel(|kernel| {
-        if kernel.tick_update(1) {
-            SCB::set_pendsv();
-        }
-    });
+extern "C" fn SysTick() {
+    if kernel::update_tick(1) {
+        SCB::set_pendsv();
+    }
 }
 
 /// PendSV interrupt handler: Context switch implementation
 ///
 /// # Safety
 ///
-/// Runs with interrupts disabled on a single-core microcontroller
+/// Runs with interrupts disabled on a single-core microcontroller.
 #[no_mangle]
 #[naked_function::naked]
-pub unsafe extern "C" fn PendSV() {
+unsafe extern "C" fn PendSV() {
     // TODO: Should work on microcontrollers without floating point hardware
     asm!(
         ".fpu fpv5-d16",                  // Enable FPU instructions
@@ -313,34 +240,15 @@ pub unsafe extern "C" fn PendSV() {
     );
 }
 
-/// Non-assembly portion of the context switch implementation
-///
-/// # Arguments
-///
-/// * `curr_task_stack_ptr`: Stack pointer of the current task
-///
-/// # Returns
-///
-/// Stack pointer of the next task
-///
-/// # Safety
-///
-/// Runs with interrupts disabled on a single-core microcontroller
 #[no_mangle]
-unsafe fn context_switch(curr_task_stack_ptr: u32) -> u32 {
-    // Using `with_kernel()` is not necessary since interrupts are disabled
-    let cs = CriticalSection::new();
-    let mut binding = KERNEL.borrow(&cs).borrow_mut();
-    let kernel = binding.as_mut().expect("Kernel not initialized");
-    kernel.handle_context_switch(Some(curr_task_stack_ptr))
+fn context_switch(curr_task_stack_ptr: u32) -> u32 {
+    kernel::run_scheduler(curr_task_stack_ptr)
 }
 
-/// Tasks should not exit
 fn task_exit() {
     loop {}
 }
 
-/// Default idle task function
 fn idle_task(_: u32) -> ! {
     loop {}
 }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,6 +8,3 @@ readme = "../README.md"
 repository = "https://github.com/bbrown1867/rucos-rs"
 license = "BSD-3-Clause"
 keywords = ["rtos"]
-
-[dependencies]
-heapless = "0.7"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rucos"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ben Brown <ben@beninter.net>"]
 edition = "2021"
 description = "Rust Microcontroller Operating System (RuCOS) Kernel"

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -1,481 +1,284 @@
-//! RuCOS kernel
+//! RuCOS Kernel
+//!
+//! This module should only be used by the "port specific" crate (e.g. `rucos-cortex-m`).
 
-use crate::task::{Task, TaskPendReason, TaskState};
-use core::cmp::PartialOrd;
-use core::default::Default;
-use core::fmt::Debug;
-use core::marker::Copy;
-use core::ops::{Add, AddAssign};
-use heapless::Vec;
+use core::ptr::null_mut;
+use core::sync::atomic::{AtomicPtr, AtomicU32, AtomicUsize, Ordering};
 
-/// Kernel
-///
-/// # Generics
-///
-/// * `SP`: The stack pointer type
-/// * `TICK`: The kernel time data type, usually a numeric type
-/// * `MAX_NUM_TASKS`: Upper bound on the number of tasks for the kernel
-pub struct Kernel<SP, TICK, const MAX_NUM_TASKS: usize> {
-    /// Kernel state
-    is_running: bool,
-    /// Global tick counter
-    tick_counter: TICK,
-    /// Task list
-    task_list: Vec<Task<SP, TICK>, MAX_NUM_TASKS>,
-    /// Current task ID
-    curr_task_id: Option<usize>,
-    /// Next task ID
-    next_task_id: Option<usize>,
+use crate::task::Task;
+
+// TODO: Somehow allow user to configure this
+const MAX_NUM_TASKS: usize = 32;
+
+static CURR_TICK: AtomicU32 = AtomicU32::new(0);
+static WAKE_TICK: AtomicU32 = AtomicU32::new(0);
+static CURR_TASK: AtomicUsize = AtomicUsize::new(MAX_NUM_TASKS);
+static IDLE_TASK: Task = Task::new(MAX_NUM_TASKS, u8::MAX);
+static TASK_TABLE: [AtomicPtr<Task>; MAX_NUM_TASKS] =
+    [const { AtomicPtr::new(null_mut()) }; MAX_NUM_TASKS];
+
+fn get_task(id: usize) -> Option<&'static Task> {
+    assert!(id <= MAX_NUM_TASKS, "Invalid task");
+
+    if id == MAX_NUM_TASKS {
+        return Some(&IDLE_TASK);
+    }
+
+    let task = TASK_TABLE[id].load(Ordering::Relaxed);
+    if task.is_null() {
+        None
+    } else {
+        // Safety: Safe dereference, since we verified the pointer is not null
+        unsafe { Some(&*TASK_TABLE[id].load(Ordering::Relaxed)) }
+    }
 }
 
-impl<SP, TICK, const MAX_NUM_TASKS: usize> Kernel<SP, TICK, MAX_NUM_TASKS>
-where
-    SP: Copy + Debug,
-    TICK: Add<Output = TICK> + AddAssign + Copy + Debug + Default + PartialOrd,
-{
-    /// Initialize the kernel
-    pub fn new() -> Self {
-        Self {
-            is_running: false,
-            tick_counter: TICK::default(),
-            task_list: Vec::new(),
-            curr_task_id: None,
-            next_task_id: None,
-        }
+/// Initialize the kernel
+///
+/// # Arguments
+///
+/// * `idle_stack_ptr`: Idle task stack pointer
+pub fn init(idle_stack_ptr: u32) {
+    IDLE_TASK.stack_ptr.store(idle_stack_ptr, Ordering::Relaxed);
+}
+
+/// Create a task
+///
+/// # Arguments
+///
+/// * `task`: Task control block
+/// * `task_stack_ptr`: Task stack pointer
+pub fn create(task: &'static Task, task_stack_ptr: u32) {
+    assert!(task.id < MAX_NUM_TASKS, "Invalid task");
+
+    task.stack_ptr.store(task_stack_ptr, Ordering::Relaxed);
+    TASK_TABLE[task.id].store(task as *const _ as *mut _, Ordering::Relaxed);
+}
+
+/// Delete a task
+///
+/// # Arguments
+///
+/// * `id`: Task to delete
+///
+/// # Returns
+///
+/// `true` if a context switch is needed, `false` otherwise
+pub fn delete(id: usize) -> bool {
+    assert!(id < MAX_NUM_TASKS, "Invalid task");
+
+    let task = get_task(id).expect("Task does not exist");
+    let is_current_task = task == get_current_task().unwrap();
+    TASK_TABLE[id].store(null_mut(), Ordering::Relaxed);
+
+    is_current_task
+}
+
+/// Get the current task
+///
+/// # Returns
+///
+/// Reference to current task or `None` if the current task was deleted
+///
+/// # Note
+///
+/// If the kernel has not been started, the idle task is returned
+pub fn get_current_task() -> Option<&'static Task> {
+    let id = CURR_TASK.load(Ordering::Relaxed);
+    if id >= MAX_NUM_TASKS {
+        Some(&IDLE_TASK)
+    } else {
+        get_task(id)
     }
+}
 
-    /// Start the kernel
-    ///
-    /// # Returns
-    ///
-    /// Stack pointer for the first task to run
-    ///
-    /// # Panics
-    ///
-    /// * No tasks have been created
-    /// * The kernel is already running
-    pub fn start(&mut self) -> SP {
-        assert!(!self.is_running, "Kernel already running");
+/// Get the system tick
+///
+/// # Returns
+///
+/// Current value of the system tick
+pub fn get_current_tick() -> u32 {
+    CURR_TICK.load(Ordering::Relaxed)
+}
 
-        self.is_running = true;
+/// Sleep the current task
+///
+/// # Arguments
+///
+/// * `delay`: Number of ticks to sleep
+///
+/// # Returns
+///
+/// `true` if a context switch is needed, `false` otherwise
+pub fn sleep(delay: u32) -> bool {
+    if delay > 0 {
+        let curr_task = get_current_task().unwrap();
+        let curr_tick = get_current_tick();
+        let wake_tick = curr_tick + delay;
+        curr_task.sleep(wake_tick);
 
-        if self.scheduler() == true {
-            self.handle_context_switch(None)
-        } else {
-            panic!("No tasks created")
-        }
-    }
-
-    /// Create a task
-    ///
-    /// # Arguments
-    ///
-    /// * `id`: Task ID
-    /// * `priority`: Task priority, with a lower number meaning higher priority
-    /// * `stack_ptr`: Task stack pointer
-    ///
-    /// # Returns
-    ///
-    /// `true` if a context switch is needed, `false` if not
-    ///
-    /// # Panics
-    ///
-    /// * The task `id` is not unique
-    /// * Too many tasks have been created, more than `MAX_NUM_TASKS`
-    ///
-    /// # Note
-    ///
-    /// The kernel does not manage the task stack, caller is responsible for
-    /// allocation and initialization of stack memory
-    pub fn create(&mut self, id: usize, priority: usize, stack_ptr: SP) -> bool {
-        // Ensure the task ID is unique
-        for task in self.task_list.iter() {
-            assert!(task.id != id, "The task ID is not unique");
-        }
-
-        self.task_list
-            .push(Task {
-                id,
-                priority,
-                stack_ptr,
-                state: TaskState::Ready,
-                pend: TaskPendReason::NotPending,
-            })
-            .expect("Number of tasks exceeds MAX_NUM_TASKS");
-
-        self.scheduler()
-    }
-
-    /// Delete a task
-    ///
-    /// # Arguments
-    ///
-    /// * `id`: Task to delete or `None` to delete the current task
-    ///
-    /// # Returns
-    ///
-    /// `true` if a context switch is needed, `false` if not
-    ///
-    /// # Panics
-    ///
-    /// * The `id` provided does not correspond to a task
-    /// * If called before the kernel is running
-    pub fn delete(&mut self, id: Option<usize>) -> bool {
-        let curr_task_idx = self.find_task_idx(self.curr_task_id.expect("Kernel not running"));
-        let task_idx = match id {
-            Some(id) => self.find_task_idx(id),
-            None => curr_task_idx,
-        };
-
-        self.task_list.remove(task_idx);
-
-        if curr_task_idx == task_idx {
-            self.curr_task_id = None;
+        let next_tick = WAKE_TICK.load(Ordering::Relaxed);
+        if next_tick < curr_tick || next_tick > wake_tick {
+            WAKE_TICK.store(wake_tick, Ordering::Relaxed);
         }
 
-        self.scheduler()
+        return true;
     }
 
-    /// Get the ID of the current task
-    ///
-    /// # Returns
-    ///
-    /// ID of the current task
-    ///
-    /// # Panics
-    ///
-    /// If called before the kernel is running
-    pub fn get_current_task(&self) -> usize {
-        self.curr_task_id.expect("Kernel not running")
-    }
+    false
+}
 
-    /// Get the value of the global tick counter
-    ///
-    /// # Returns
-    ///
-    /// Current value of the global tick counter
-    pub fn get_current_tick(&self) -> TICK {
-        self.tick_counter
-    }
+/// Suspend a task
+///
+/// # Arguments
+///
+/// * `id`: Task to suspend
+///
+/// # Returns
+///
+/// `true` if a context switch is needed, `false` otherwise
+pub fn suspend(id: usize) -> bool {
+    let task = get_task(id).expect("Task does not exist");
+    task.suspend();
+    task == get_current_task().unwrap()
+}
 
-    /// Sleep the current task
-    ///
-    /// # Arguments
-    ///
-    /// * `delay`: Number of ticks to sleep
-    ///
-    /// # Returns
-    ///
-    /// `true` if a context switch is needed, `false` if not
-    ///
-    /// # Panics
-    ///
-    /// If called before the kernel is running
-    pub fn sleep(&mut self, delay: TICK) -> bool {
-        let new_tick_counter = self.tick_counter + delay;
-        let curr_task = self.find_task(self.curr_task_id.expect("Kernel not running"));
+/// Resume a task
+///
+/// # Arguments
+///
+/// * `id`: Task to resume
+pub fn resume(id: usize) {
+    let task = get_task(id).expect("Task does not exist");
+    task.ready();
+}
 
-        curr_task.state = TaskState::Pending;
-        curr_task.pend = TaskPendReason::Sleep(new_tick_counter);
+/// Run the scheduler
+///
+/// # Arguments
+///
+/// * `curr_task_stack_ptr`: Updated stack pointer for the current task
+///
+/// # Returns
+///
+/// Stack pointer for the next task
+///
+/// # Note
+///
+/// This function should be run atomically (e.g. interrupts disabled)
+pub fn run_scheduler(curr_task_stack_ptr: u32) -> u32 {
+    let curr_task = get_current_task();
+    let curr_tick = get_current_tick();
 
-        self.scheduler()
-    }
+    // Update current task stack pointer
+    match curr_task {
+        Some(task) => task.stack_ptr.store(curr_task_stack_ptr, Ordering::Relaxed),
+        // Current task was deleted
+        None => (),
+    };
 
-    /// Suspend a task
-    ///
-    /// # Arguments
-    ///
-    /// * `id`: Task to suspend or `None` to suspend the current task
-    ///
-    /// # Returns
-    ///
-    /// `true` if a context switch is needed, `false` if not
-    ///
-    /// # Panics
-    ///
-    /// * The `id` provided does not correspond to a task
-    /// * If called before the kernel is running
-    pub fn suspend(&mut self, id: Option<usize>) -> bool {
-        let task: &mut Task<SP, TICK> = match id {
-            Some(id) => self.find_task(id),
-            None => {
-                let curr_task_id = self.curr_task_id.expect("Kernel not running");
-                self.find_task(curr_task_id)
-            }
-        };
+    // Idle task is always ready to run
+    let mut next_task = &IDLE_TASK;
 
-        task.state = TaskState::Pending;
-        task.pend = TaskPendReason::Suspended;
+    // Find the highest priority task ready to run
+    // TODO: Add time slicing (round-robin) if multiple tasks with the same priority are ready
+    for i in 0..MAX_NUM_TASKS {
+        match get_task(i) {
+            Some(task) => {
+                if task.is_sleep() && task.wake_tick() <= curr_tick {
+                    task.ready();
+                }
 
-        self.scheduler()
-    }
-
-    /// Resume a task
-    ///
-    /// # Arguments
-    ///
-    /// * `id`: Task to resume
-    ///
-    /// # Returns
-    ///
-    /// `true` if a context switch is needed, `false` if not
-    ///
-    /// # Panics
-    ///
-    /// The `id` provided does not correspond to a task
-    pub fn resume(&mut self, id: usize) -> bool {
-        let task: &mut Task<SP, TICK> = self.find_task(id);
-
-        task.state = TaskState::Ready;
-        task.pend = TaskPendReason::NotPending;
-
-        self.scheduler()
-    }
-
-    /// Update the global tick counter
-    ///
-    /// # Arguments
-    ///
-    /// * `elapsed`: Number of ticks that have passed since last call
-    ///
-    /// # Returns
-    ///
-    /// `true` if a context switch is needed, `false` if not
-    pub fn tick_update(&mut self, elapsed: TICK) -> bool {
-        self.tick_counter += elapsed;
-
-        self.scheduler()
-    }
-
-    /// Handle a context switch
-    ///
-    /// # Arguments
-    ///
-    /// * `updated_stack_ptr`: The updated stack pointer for the current task or
-    ///   `None` if there is no current task
-    ///
-    /// # Returns
-    ///
-    /// The stack pointer for the next task
-    ///
-    /// # Panics
-    ///
-    /// If called when a context switch is not necessary
-    pub fn handle_context_switch(&mut self, updated_stack_ptr: Option<SP>) -> SP {
-        // Update current task
-        match self.curr_task_id {
-            Some(curr_task_id) => {
-                let curr_task = self.find_task(curr_task_id);
-
-                match updated_stack_ptr {
-                    Some(sp) => curr_task.stack_ptr = sp,
-                    None => (),
-                };
-
-                curr_task.state = match curr_task.state {
-                    TaskState::Running => TaskState::Ready,
-                    _ => curr_task.state,
-                };
+                // Remember: Lower value means higher priority
+                if task.is_ready() && task.priority < next_task.priority {
+                    next_task = task;
+                }
             }
             None => (),
         }
-
-        // Update kernel
-        let next_task_id = self.next_task_id.expect("No context switch required");
-        self.curr_task_id = Some(next_task_id);
-        self.next_task_id = None;
-
-        // Update next task
-        let next_task = self.find_task(next_task_id);
-        next_task.state = TaskState::Running;
-
-        // Return the next task stack pointer
-        next_task.stack_ptr
     }
 
-    fn scheduler(&mut self) -> bool {
-        if !self.is_running {
-            return false;
-        }
-
-        // Update pending tasks, as they might be ready to run now
-        self.update_pending_tasks();
-
-        // Update next task to run
-        match self.find_highest_priority_runnable_task() {
-            Some(next_task_id) => {
-                match self.curr_task_id {
-                    Some(curr_task_id) => {
-                        // Case 1: Current task should continue running
-                        if curr_task_id == next_task_id {
-                            self.next_task_id = None;
-                        // Case 2: Current task should be switched out
-                        } else {
-                            self.next_task_id = Some(next_task_id);
-                        }
-                    }
-                    // Case 3: There is no current task (starting the kernel)
-                    None => self.next_task_id = Some(next_task_id),
-                }
-            }
-            // All tasks pending, nothing to do
-            None => self.next_task_id = None,
-        }
-
-        !(self.next_task_id == None)
+    if curr_task.is_none() || next_task != curr_task.unwrap() {
+        CURR_TASK.store(next_task.id, Ordering::Relaxed);
+        next_task.stack_ptr.load(Ordering::Relaxed)
+    } else {
+        curr_task_stack_ptr
     }
+}
 
-    fn update_pending_tasks(&mut self) {
-        for task in self.task_list.iter_mut() {
-            match task.pend {
-                TaskPendReason::Sleep(timeout) => {
-                    if self.tick_counter >= timeout {
-                        task.state = TaskState::Ready;
-                        task.pend = TaskPendReason::NotPending;
-                    }
-                }
-                _ => (),
-            }
-        }
-    }
-
-    // TODO: Assumes only one task per priority level, no time slicing
-    fn find_highest_priority_runnable_task(&self) -> Option<usize> {
-        let mut highest_prio_runnable_task: Option<&Task<SP, TICK>> = None;
-        for task in self.task_list.iter() {
-            if task.is_runnable() {
-                highest_prio_runnable_task = match highest_prio_runnable_task {
-                    Some(other) => {
-                        if task < other {
-                            Some(task)
-                        } else {
-                            Some(other)
-                        }
-                    }
-                    None => Some(task),
-                };
-            }
-        }
-
-        match highest_prio_runnable_task {
-            Some(task) => Some(task.id),
-            None => None,
-        }
-    }
-
-    fn find_task(&mut self, id: usize) -> &mut Task<SP, TICK> {
-        self.task_list
-            .iter_mut()
-            .find(|t| t.id == id)
-            .expect("Task does not exist")
-    }
-
-    fn find_task_idx(&self, id: usize) -> usize {
-        self.task_list
-            .iter()
-            .position(|t| t.id == id)
-            .expect("Task does not exist")
-    }
+/// Update the system tick
+///
+/// # Arguments
+///
+/// * `elapsed`: Number of ticks elapsed since last call
+///
+/// # Returns
+///
+/// `true` if a context switch is needed, `false` otherwise
+pub fn update_tick(elapsed: u32) -> bool {
+    let curr_tick = CURR_TICK.fetch_add(elapsed, Ordering::Relaxed) + elapsed;
+    let wake_tick = WAKE_TICK.load(Ordering::Relaxed);
+    wake_tick <= curr_tick
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn setup() -> Kernel<u32, u64, 2> {
-        let mut kernel = Kernel::new();
+    static TASK0: Task = Task::new(0, 10);
+    static TASK1: Task = Task::new(1, 11);
+    static TASK2: Task = Task::new(2, 12);
 
-        let mut task0_stack: [u8; 128] = [0; 128];
-        kernel.create(0, 99, task0_stack.as_mut_ptr() as u32);
+    #[test]
+    fn test_create() {
+        create(&TASK0, 0xDEADBEEF);
+        create(&TASK1, 0xDEADBEEF);
+        create(&TASK2, 0xDEADBEEF);
 
-        let mut task1_stack: [u8; 128] = [0; 128];
-        kernel.create(1, 100, task1_stack.as_mut_ptr() as u32);
-
-        kernel.start();
-        assert_eq!(kernel.curr_task_id, Some(0));
-        assert_eq!(kernel.next_task_id, None);
-        assert_eq!(kernel.get_current_task(), 0);
-
-        kernel
+        assert_eq!(get_task(0).unwrap(), &TASK0);
+        assert_eq!(get_task(1).unwrap(), &TASK1);
+        assert_eq!(get_task(2).unwrap(), &TASK2);
+        assert_eq!(get_task(3), None);
     }
 
     #[test]
-    fn test_sleep() {
-        let mut kernel = setup();
-
-        assert_eq!(kernel.sleep(2), true);
-        assert_eq!(kernel.curr_task_id, Some(0));
-        assert_eq!(kernel.next_task_id, Some(1));
-
-        let _ = kernel.handle_context_switch(None);
-
-        assert_eq!(kernel.curr_task_id, Some(1));
-        assert_eq!(kernel.next_task_id, None);
-        assert_eq!(kernel.get_current_task(), 1);
-
-        assert_eq!(kernel.tick_update(3), true);
-        assert_eq!(kernel.get_current_tick(), 3);
-        assert_eq!(kernel.curr_task_id, Some(1));
-        assert_eq!(kernel.next_task_id, Some(0));
+    fn test_delete() {
+        create(&TASK0, 0xDEADBEEF);
+        assert_eq!(delete(0), false);
+        assert_eq!(get_task(0), None);
     }
 
     #[test]
-    fn test_suspend_current_task() {
-        let mut kernel = setup();
-
-        assert_eq!(kernel.suspend(None), true);
-        assert_eq!(kernel.curr_task_id, Some(0));
-        assert_eq!(kernel.next_task_id, Some(1));
+    fn test_suspend_and_resume() {
+        create(&TASK0, 0xDEADBEEF);
+        assert_eq!(suspend(0), false);
+        assert!(TASK0.is_suspended());
+        resume(0);
+        assert!(TASK0.is_ready())
     }
 
     #[test]
-    fn test_suspend_other_task() {
-        let mut kernel = setup();
+    fn test_run_scheduler() {
+        let task0_stack_ptr = 0xAA;
+        let task1_stack_ptr = 0xBB;
+        let task2_stack_ptr = 0xCC;
+        create(&TASK0, task0_stack_ptr);
+        create(&TASK1, task1_stack_ptr);
+        create(&TASK2, task2_stack_ptr);
 
-        assert_eq!(kernel.suspend(Some(1)), false);
-        assert_eq!(kernel.curr_task_id, Some(0));
-        assert_eq!(kernel.next_task_id, None);
+        assert_eq!(run_scheduler(task0_stack_ptr), task0_stack_ptr);
+        assert_eq!(get_current_task(), Some(&TASK0));
+        TASK0.sleep(5);
+        assert_eq!(run_scheduler(task0_stack_ptr), task1_stack_ptr);
+        assert_eq!(get_current_task(), Some(&TASK1));
+        TASK1.sleep(5);
+        assert_eq!(run_scheduler(task1_stack_ptr), task2_stack_ptr);
+        assert_eq!(get_current_task(), Some(&TASK2));
     }
 
     #[test]
-    fn test_resume() {
-        let mut kernel = setup();
-
-        let _ = kernel.suspend(None);
-        let _ = kernel.handle_context_switch(None);
-
-        assert_eq!(kernel.resume(0), true);
-        assert_eq!(kernel.curr_task_id, Some(1));
-        assert_eq!(kernel.next_task_id, Some(0));
-    }
-
-    #[test]
-    fn test_delete_current_task() {
-        let mut kernel = setup();
-
-        assert_eq!(kernel.delete(None), true);
-        assert_eq!(kernel.curr_task_id, None);
-        assert_eq!(kernel.next_task_id, Some(1));
-    }
-
-    #[test]
-    fn test_delete_current_task_by_id() {
-        let mut kernel = setup();
-
-        assert_eq!(kernel.delete(Some(0)), true);
-        assert_eq!(kernel.curr_task_id, None);
-        assert_eq!(kernel.next_task_id, Some(1));
-    }
-
-    #[test]
-    fn test_delete_other_task() {
-        let mut kernel = setup();
-
-        let _ = kernel.suspend(None);
-        let _ = kernel.handle_context_switch(None);
-
-        assert_eq!(kernel.delete(Some(0)), false);
-        assert_eq!(kernel.curr_task_id, Some(1));
-        assert_eq!(kernel.next_task_id, None);
+    fn test_update_tick() {
+        update_tick(3);
+        assert_eq!(get_current_tick(), 3);
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,8 +1,6 @@
-//! Rust Microcontroller Operating System (RuCOS) Kernel
+//! Rust Microcontroller Operating System (RuCOS)
 
 #![cfg_attr(not(test), no_std)]
 
 pub mod kernel;
-mod task;
-
-pub use kernel::Kernel;
+pub mod task;

--- a/kernel/src/task.rs
+++ b/kernel/src/task.rs
@@ -1,74 +1,136 @@
 //! RuCOS Task
+//!
+//! Users can initialize tasks using [`Task::new`], providing an identifier ([`Task::id`]) and a
+//! task priority. The [`Task`] must have `static` lifetime and the idenfitier must be a unique
+//! integer in the range `[0:MAX_NUM_TASKS)`.
 
-use core::cmp::{Ordering, PartialOrd};
+use core::cmp::{self, PartialOrd};
+use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 
 /// Task states
+#[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum TaskState {
-    /// Waiting for some event
-    Pending,
-    /// Ready to run
-    Ready,
-    /// Currently running
-    Running,
+enum TaskState {
+    Ready = 0,
+    Sleep = 1,
+    Suspend = 2,
 }
 
-/// Task pend reasons and associated pend data
-///
-/// # Generics
-///
-/// * `TICK`: The kernel time data type, usually a numeric type
-#[derive(Debug)]
-pub enum TaskPendReason<TICK> {
-    /// The task is not pending
-    NotPending,
-    /// The task is suspended
-    Suspended,
-    /// The task is sleeping until some tick count in the future
-    Sleep(TICK),
+impl From<u8> for TaskState {
+    fn from(v: u8) -> Self {
+        match v {
+            0 => TaskState::Ready,
+            1 => TaskState::Sleep,
+            2 => TaskState::Suspend,
+            _ => panic!("Invalid task state"),
+        }
+    }
 }
 
 /// Task control block
-///
-/// # Generics
-///
-/// * `SP`: The stack pointer type
-/// * `TICK`: The kernel time data type, usually a numeric type
 #[derive(Debug)]
-pub struct Task<SP, TICK> {
-    /// Task ID
+pub struct Task {
+    /// Task identifier
     pub id: usize,
     /// Task priority
-    pub priority: usize,
+    pub priority: u8,
     /// Task stack pointer
-    pub stack_ptr: SP,
+    pub stack_ptr: AtomicU32,
+    /// Task wake tick
+    wake_tick: AtomicU32,
     /// Task state
-    pub state: TaskState,
-    /// Task pend reason
-    pub pend: TaskPendReason<TICK>,
+    state: AtomicU8,
 }
 
-/// Allow comparison of tasks using priority level
-impl<SP, TICK> PartialEq for Task<SP, TICK> {
+impl Task {
+    /// Create a task
+    ///
+    /// # Arguments
+    ///
+    /// * `id`: Unique ID of the task; should be in range `[0:MAX_NUM_TASKS)`
+    /// * `priority`: Priority of the task; lower number means higher priority
+    ///
+    /// # Returns
+    ///
+    /// New task control block
+    pub const fn new(id: usize, priority: u8) -> Self {
+        Task {
+            id: id,
+            priority: priority,
+            stack_ptr: AtomicU32::new(0),
+            state: AtomicU8::new(TaskState::Ready as u8),
+            wake_tick: AtomicU32::new(0),
+        }
+    }
+
+    /// Mark the task as ready to run
+    pub fn ready(&self) {
+        self.state.store(TaskState::Ready as u8, Ordering::Relaxed);
+    }
+
+    /// Check if the task is ready to run
+    ///
+    /// # Returns
+    ///
+    /// `true` if the task is ready to run, `false` otherwise
+    pub fn is_ready(&self) -> bool {
+        TaskState::from(self.state.load(Ordering::Relaxed)) == TaskState::Ready
+    }
+
+    /// Mark the task as sleeping
+    ///
+    /// # Arguments
+    ///
+    /// * `wake_tike`: Absolute system tick to sleep until
+    pub fn sleep(&self, wake_tick: u32) {
+        self.wake_tick.store(wake_tick, Ordering::Relaxed);
+        self.state.store(TaskState::Sleep as u8, Ordering::Relaxed);
+    }
+
+    /// Check if the task is asleep
+    ///
+    /// # Returns
+    ///
+    /// `true` if the task is asleep, `false` otherwise
+    pub fn is_sleep(&self) -> bool {
+        TaskState::from(self.state.load(Ordering::Relaxed)) == TaskState::Sleep
+    }
+
+    /// Mark the task as suspended
+    pub fn suspend(&self) {
+        self.state
+            .store(TaskState::Suspend as u8, Ordering::Relaxed);
+    }
+
+    /// Check if the task is suspended
+    ///
+    /// # Returns
+    ///
+    /// `true` if the task is suspended, `false` otherwise
+    pub fn is_suspended(&self) -> bool {
+        TaskState::from(self.state.load(Ordering::Relaxed)) == TaskState::Suspend
+    }
+
+    /// Get the wake tick for the task
+    ///
+    /// # Returns
+    ///
+    /// Wake tick
+    pub fn wake_tick(&self) -> u32 {
+        self.wake_tick.load(Ordering::Relaxed)
+    }
+}
+
+// Implemented to allow comparison of tasks using priority level
+impl PartialEq for Task {
     fn eq(&self, other: &Self) -> bool {
         self.priority == other.priority
     }
 }
 
-/// Allow comparison of tasks using priority level
-impl<SP, TICK> PartialOrd for Task<SP, TICK> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+// Implemented to allow comparison of tasks using priority level
+impl PartialOrd for Task {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.priority.cmp(&other.priority))
-    }
-}
-
-impl<SP, TICK> Task<SP, TICK> {
-    /// Check if the task is runnable
-    ///
-    /// # Returns
-    ///
-    /// `true` if the task is runnable, `false` if not
-    pub fn is_runnable(&self) -> bool {
-        self.state == TaskState::Ready || self.state == TaskState::Running
     }
 }


### PR DESCRIPTION
Total rewrite of the `rucos` crate to avoid needing a `Kernel` singleton, which requires interrupts are disabled whenever it is used. Instead, the application owns a task control block (`Task`) and the `rucos` crate maintains a small set of `static` `Atomic` variables, that can be accessed without disabling interrupts. The scheduler is still run with interrupts disabled, just from the PendSV handler.

For simplicity, generics for stack pointer (`SP`), system tick (`TICK`), and max number of tasks are dropped. `u32` is used for the first two and currently `MAX_NUM_TASKS` is hard-coded.

Version bumped to 0.3.0.